### PR TITLE
footer: update copyright year

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,7 @@
 
   <div class="content-wrapper">
     <div class="content">
-      <p>© 2016 ClojureBridge</p>
+      <p>© {{ 'now' | date: '%Y' }} ClojureBridge</p>
     </div>
   </div>
 


### PR DESCRIPTION
Source: [Get The Current Year In Jekyll][1]


[1]: http://www.adamwadeharris.com/get-current-year-in-jekyll/
