### PR TITLE
reinstate trailing slash in Code of Conduct link

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,7 +14,7 @@
       {% endif %}
     {% endfor %}
       <li>
-        <a class="page-link" href="https://bridgefoundry.org/code-of-conduct">Code of Conduct</a>
+        <a class="page-link" href="https://bridgefoundry.org/code-of-conduct/">Code of Conduct</a>
       </li>
       <li>
         <a class="page-link" href="https://github.com/ClojureBridge"><i class="fa fa-github"><span>GitHub</span></i></a>


### PR DESCRIPTION
Sarah Allen, via email:

> I realized that if when I set the css up to work without the slash, the links were broken.  I put it back to the way it was with the trailing slash for now... css looks wrong without the trailing slash.  I haven't yet figure out how to make both work...
>
> Can you leave ClojureBridge Website to use the trailing slash for now?  If that is the way it was, probably it is better to leave it that way.
