### PR TITLE
configure Travis to run dummy deployment script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,9 @@ before_install:
 script:
   - node_modules/.bin/lumo validate-yaml.cljs
   - bundle exec jekyll build
+
+deploy:
+  provider: script
+  script: scripts/deploy
+  on:
+    branch: master

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euf -o pipefail
+
+git remote --verbose
+git branch --list


### PR DESCRIPTION
I have configured Travis (via the UI) to “deploy” every day. Next I'd like to see whether `scripts/deploy` is actually run at about this time tomorrow. If so, the final step is to update the script to rebuild the site and push the updates to GitHub.
