### PR TITLE
Revert "travis: update site upon successful build"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,7 @@ script:
   - bundle exec jekyll build
 
 deploy:
-  - provider: pages
-    skip-cleanup: true
-    github-token: $GITHUB_TOKEN
-    target-branch: master
-    keep-history: true
-    on:
-      branch: master
-  - provider: script
-    script: scripts/deploy
-    on:
-      branch: master
+  provider: script
+  script: scripts/deploy
+  on:
+    branch: master


### PR DESCRIPTION
Reverts #52

I misunderstood how GitHub Pages is configured for this repository; #52 was not correct. As can be seen in <https://travis-ci.org/ClojureBridge/clojurebridge.github.io/builds/400404497>, Travis attempted to push an enormous commit to GitHub, which (fortunately) failed.
