### PR TITLE
travis: update site upon successful build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,4 @@ deploy:
   script: scripts/deploy
   on:
     branch: master
+    condition: "$(git log --format=%s --max-count=1 master)" != "$(TZ=UTC date +%Y-%m-%d) update"

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -3,3 +3,16 @@ set -euf -o pipefail
 
 git remote --verbose
 git branch --list
+
+git checkout master
+
+git -c user.name='clojurebridge-machine' \
+    -c user.email='40778920+clojurebridge-machine@users.noreply.github.com' \
+    commit \
+    --allow-empty \
+    --message "$(TZ=UTC date +%Y-%m-%d) update"
+
+git push \
+    --quiet \
+    "https://clojurebridge-machine:$GITHUB_TOKEN@github.com/ClojureBridge/clojurebridge.github.io" \
+    master


### PR DESCRIPTION
#52 did too much. I now understand that pushing an empty commit to `master` is sufficient to prompt GitHub to update the static site. The final piece of the puzzle is a condition to prevent an infinite loop, since pushing a commit to `master` triggers `scripts/deploy` and `scripts/deploy` pushes to `master`.
