### PR TITLE
display GitHub and Twitter links conditionally

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -47,14 +47,18 @@ layout: default
                 Find {{ organizer.name }} on social media:
               </p>
               <ul>
+              {% if organizer.github %}
                 <li>
                   <i class="fa fa-github"></i>
                   <a href="https://github.com/{{ organizer.github }}">{{ organizer.github }}</a>
                 </li>
+              {% endif %}
+              {% if organizer.twitter %}
                 <li>
                   <i class="fa fa-twitter"></i>
                   <a href="https://twitter.com/{{ organizer.twitter }}">{{ organizer.twitter }}</a>
                 </li>
+              {% endif %}
               </ul>
             {% endif %}
           {% endif %}


### PR DESCRIPTION
While investigating another issue I noticed that <https://clojurebridge.org/events/2014-09-26-san-francisco> currently displays a Twitter icon even though I didn't specify my Twitter username.
