### PR TITLE
travis: remove vestigial deployment condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,3 @@ deploy:
   script: scripts/deploy
   on:
     branch: master
-    condition: "$(git log --format=%s --max-count=1 master)" != "$(TZ=UTC date +%Y-%m-%d) update"


### PR DESCRIPTION
I just noticed that Travis has been unable to parse __.travis.yml__ since I merged #58. This pull request removes the problematic line, activating Travis.
