### PR TITLE
Rename PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,4 @@
-<!--
-Ticket title:
-  New ClojureBridge workshop on {DATE} in {CITY}
--->
+<!-- Ticket title: New ClojureBridge workshop on {DATE} in {CITY} -->
 
 ## Adding a new event to the website
 


### PR DESCRIPTION
Looks like the PR template added in #84 does not work as expected, since (#86) was opened iwthout the template content. Unfortunately there is no good way to test these templates before merging. However I am fairly confident this new format is correct. (see docs: https://help.github.com/en/github/building-a-strong-community/creating-a-pull-request-template-for-your-repository) 