### PR TITLE
New ClojureBridge workshop on 17 Sept 2022 in London

### DIFF
--- a/_posts/2022-09-17-london.md
+++ b/_posts/2022-09-17-london.md
@@ -1,0 +1,28 @@
+---
+layout:             post
+permalink:          /events/2022-09-17-london
+country:            United Kingdom
+city:               London
+street:             Signal, WeWork, 145 City Rd, Hoxton, London EC1V 1AW
+latitude:           51.527673
+longitude:          -0.088374
+start-date:         2022-09-16
+end-date:           2022-09-17
+registration-url:   https://clojurebridgelondon.github.io/
+city-image-url:     assets/images/events/london.jpg
+gravatar-email:
+organizers:         [{"email": null, "name": "Mayur Dave", "twitter": "mdave16", "github": "mdave16"}
+                    ,{"email": null, "name": "John Stevenson", "twitter": "jr0cket", "github": "jr0cket"}
+                    ,{"email": null, "name": "David Harrigan", "twitter": "ldnclj", "github": "dharrigan"}]
+sponsors:           [{"image": "https://www.signal-ai.com/wp-content/themes/signal/assets/img/logo.svg", "name": "Signal", "url": "https://www.signal-ai.com/"}]
+---
+
+### Description
+
+ClojureBridge is a free, beginner-friendly workshop teaching the Clojure programming language, primarily for trans/cis women and non-binary people. ClojureBridge is emphatically queer and trans\* friendly.
+
+You’ll learn fundamental programming concepts in Clojure through practical examples and exercises. Teachers and assistants are there to guide you and help you build your first apps in Clojure.
+
+The workshop is open to people who are completely new to programming, through to existing developers new to Clojure. We organise attendees into small groups with at least one teacher and one assistant.
+
+Priority is given to those who identify as trans or cis women and/or non-binary. Men may register as a guest of one of these participants.

--- a/_posts/2022-09-17-london.md
+++ b/_posts/2022-09-17-london.md
@@ -12,7 +12,7 @@ registration-url:   https://clojurebridgelondon.github.io/
 city-image-url:     assets/images/events/london.jpg
 gravatar-email:
 organizers:         [{"email": null, "name": "Mayur Dave", "twitter": "mdave16", "github": "mdave16"}
-                    ,{"email": null, "name": "John Stevenson", "twitter": "jr0cket", "github": "jr0cket"}
+                    ,{"email": null, "name": "John Stevenson", "twitter": "practical_li", "github": "practicalli-john"}
                     ,{"email": null, "name": "David Harrigan", "twitter": "ldnclj", "github": "dharrigan"}]
 sponsors:           [{"image": "https://www.signal-ai.com/wp-content/themes/signal/assets/img/logo.svg", "name": "Signal", "url": "https://www.signal-ai.com/"}]
 ---


### PR DESCRIPTION
<!-- Ticket title: New ClojureBridge workshop on {DATE} in {CITY} -->

## Adding a new event to the website

* [x] Start by copying the [events post template](./github/post_template.md) to the `_post` directory.
* [x] Rename the file like `YYYY-MM-dd-LOCATION.md`, e.g. `2019-08-01-berlin.md`
* [x] Fill out the details in the template.
* [x] Open a PR.
* [ ] Wait for Travis CI to pass.
* [ ] Get a review from someone on @ClojureBridge/Board
* [ ] Merge the PR
* [ ] Test your change by navigating to https://clojurebridge.org/ and verifying your event looks good
* [ ] :tada: Celebrate!
